### PR TITLE
updating webappkind enum

### DIFF
--- a/lib/actionparameters.js
+++ b/lib/actionparameters.js
@@ -19,7 +19,7 @@ var WebAppKind;
 exports.appKindMap = new Map([
     ['app', WebAppKind.Windows],
     ['app,linux', WebAppKind.Linux],
-    ['app,container,xenon', WebAppKind.WindowsContainer],
+    ['app,container,windows', WebAppKind.WindowsContainer],
     ['app,linux,container', WebAppKind.LinuxContainer]
 ]);
 class ActionParameters {

--- a/src/actionparameters.ts
+++ b/src/actionparameters.ts
@@ -13,7 +13,7 @@ export enum WebAppKind {
 export const appKindMap = new Map([
     [ 'app', WebAppKind.Windows ],
     [ 'app,linux', WebAppKind.Linux ],
-    [ 'app,container,xenon', WebAppKind.WindowsContainer ],
+    [ 'app,container,windows', WebAppKind.WindowsContainer ],
     [ 'app,linux,container', WebAppKind.LinuxContainer ]
 ]);
 


### PR DESCRIPTION
Response from Resources list ARM API has changed for windows Web App container, hence the update.

API request:
GET https://management.azure.com/subscriptions/c94bda7a-0577-4374-9c53-0e46a9fb0f70/resources?api-version=2016-07-01

Response:
 {
      "id": "/subscriptions/c94bda7a-0577-4374-9c53-0e46a9fb0f70/resourceGroups/akshaya-tests/providers/Microsoft.Web/sites/ak-win-container-enum",
      "name": "ak-win-container-enum",
      "type": "Microsoft.Web/sites",
      **"kind": "app,container,windows"**,
      "location": "northeurope"
}

For web apps and linux container apps, there is no change in response