### PR TITLE
Add kind *api* to actionparameters.ts

### DIFF
--- a/src/actionparameters.ts
+++ b/src/actionparameters.ts
@@ -14,7 +14,8 @@ export const appKindMap = new Map([
     [ 'app', WebAppKind.Windows ],
     [ 'app,linux', WebAppKind.Linux ],
     [ 'app,container,windows', WebAppKind.WindowsContainer ],
-    [ 'app,linux,container', WebAppKind.LinuxContainer ]
+    [ 'app,linux,container', WebAppKind.LinuxContainer ],
+    [ 'api', WebAppKind.Windows ],
 ]);
 
 export class ActionParameters {


### PR DESCRIPTION
Closes #106 

I've tested this for a Windows API Webapp based on v2.1.5. There are probably more API _kinds_ that need to be included. My PR does not include the updated actionparameters.js.