### PR TITLE
Adding a workflow to label stale issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,25 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "0 0/3 * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been open for 14 days with no activity. Please remove the stale label or comment on the issue otherwise this will be closed in 5 days'
+        stale-pr-message: 'This PR is stale because it has been open for 14 days with no activity.'
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale'
+        days-before-stale: 14
+        days-before-issue-close: 5
+        days-before-pr-close: -1
+        operations-per-run: 100
+        exempt-issue-labels: 'backlog'
+        remove-stale-when-updated: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,10 +1,6 @@
 name: Mark stale issues and pull requests
 
 on:
-  pull_request:
-    branches:
-      - master
-  workflow_dispatch:
   schedule:
   - cron: "0 0/3 * * *"
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,9 @@
 name: Mark stale issues and pull requests
 
 on:
+  pull_request:
+    branches:
+      - master
   workflow_dispatch:
   schedule:
   - cron: "0 0/3 * * *"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,7 @@
 name: Mark stale issues and pull requests
 
 on:
+  workflow_dispatch:
   schedule:
   - cron: "0 0/3 * * *"
 


### PR DESCRIPTION
1. Creating a workflow to label stale issues and PRs which have been open for 14 days with no activity.
2. Also close the stale issue in 5 days. PRs are not closed automatically as of now.