### PR TITLE
Fix typo in command name `az ad sp create-for-rbac`

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ The following steps describe how to create the service principal, assign the rol
 
 1. Open the Azure Cloud Shell at [https://shell.azure.com](https://shell.azure.com). You can alternately use the [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli?view=azure-cli-latest) if you've installed it locally. (For more information on Cloud Shell, see the [Cloud Shell Overview](https://docs.microsoft.com/azure/cloud-shell/overview).)
   
-2. Use the [az ad dp create-for-rbac](https://docs.microsoft.com/cli/azure/ad/sp?view=azure-cli-latest#az_ad_sp_create_for_rbac) command to create a service principal and assign a Contributor role:
+2. Use the [az ad sp create-for-rbac](https://docs.microsoft.com/cli/azure/ad/sp?view=azure-cli-latest#az_ad_sp_create_for_rbac) command to create a service principal and assign a Contributor role:
 
     ```azurecli
     az ad sp create-for-rbac --name "{sp-name}" --sdk-auth --role contributor \


### PR DESCRIPTION
👋    everything else refers to `sp` so I assume this is just a typo.