### PR TITLE
Trim commit message to not include description

### DIFF
--- a/lib/actionparameters.js
+++ b/lib/actionparameters.js
@@ -32,7 +32,7 @@ class ActionParameters {
         this._images = core.getInput('images');
         this._multiContainerConfigFile = core.getInput('configuration-file');
         this._startupCommand = core.getInput('startup-command');
-        this._commitMessage = github.context.eventName === 'push' ? github.context.payload.head_commit.message : "";
+        this._commitMessage = github.context.eventName === 'push' ? github.context.payload.head_commit.message.split(/\r?\n/)[0] : "";
         this._endpoint = endpoint;
     }
     static getActionParams(endpoint) {

--- a/src/actionparameters.ts
+++ b/src/actionparameters.ts
@@ -43,7 +43,7 @@ export class ActionParameters {
         this._images = core.getInput('images');
         this._multiContainerConfigFile = core.getInput('configuration-file');
         this._startupCommand = core.getInput('startup-command');
-        this._commitMessage = github.context.eventName === 'push'? github.context.payload.head_commit.message: "";
+        this._commitMessage = github.context.eventName === 'push'? github.context.payload.head_commit.message.split(/\r?\n/)[0] : "";
         this._endpoint = endpoint;    
     }
 


### PR DESCRIPTION
Resolves https://github.com/Azure/webapps-deploy/issues/192.

I considered trimming the commit message to a certain length, but it appears that it would be hard to completely predict how long the message sent to Kudu is since the message contains more than just the commit message. It seems reasonable to just include the first line of the commit message.