### PR TITLE
Update action settings to use Node v16 runtime

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,5 +32,5 @@ branding:
   icon: 'webapp.svg'
   color: 'blue'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'lib/main.js'


### PR DESCRIPTION
As mentioned in #253 GitHub has started the deprecation process of Node 12. This change simply bumps the version from node12 to node16.

npm tests passed on Node versions 16.15.1 and 16.18.0.