### PR TITLE
Added node version 16 in action.yml at line no.35

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,5 +32,5 @@ branding:
   icon: 'webapp.svg'
   color: 'blue'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'lib/main.js'


### PR DESCRIPTION
This change was done for below warning message.

: Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: azure/webapps-deploy@v2