### PR TITLE
Trim commit message

### DIFF
--- a/lib/actionparameters.js
+++ b/lib/actionparameters.js
@@ -37,7 +37,7 @@ class ActionParameters {
         /**
          * Trimming the commit message because it is used as a param in uri of deployment api. And sometimes, it exceeds the max length of http URI.
          */
-        this._commitMessage = github.context.eventName === 'push' ? github.context.payload.head_commit.message.slice(0, 7000) : "";
+        this._commitMessage = github.context.eventName === 'push' ? github.context.payload.head_commit.message.slice(0, 1000) : "";
         this._endpoint = endpoint;
     }
     static getActionParams(endpoint) {

--- a/src/actionparameters.ts
+++ b/src/actionparameters.ts
@@ -48,7 +48,7 @@ export class ActionParameters {
         /**
          * Trimming the commit message because it is used as a param in uri of deployment api. And sometimes, it exceeds the max length of http URI.
          */
-        this._commitMessage = github.context.eventName === 'push' ? github.context.payload.head_commit.message.slice(0, 7000) : "";
+        this._commitMessage = github.context.eventName === 'push' ? github.context.payload.head_commit.message.slice(0, 1000) : "";
         this._endpoint = endpoint;
     }
 


### PR DESCRIPTION
This covers https://github.com/Azure/webapps-deploy/issues/288.

Recently we found out that 7000 doesn't work in some scenarios intermittently, keeping it a bit lower for the deployment to go through.