### PR TITLE
Change images "required" value

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     default: '.'
   images:
     description: "Applies to Web App Containers only: Specify the fully qualified container image(s) name. For example, 'myregistry.azurecr.io/nginx:latest' or 'python:3.7.2-alpine/'. For multi-container scenario multiple container image names can be provided (multi-line separated)"
-    required: true
+    required: false
   configuration-file:
     description: 'Applies to Web App Containers only: Path of the Docker-Compose file. Should be a fully qualified path or relative to the default working directory. Required for multi-container scenario'
     required: false


### PR DESCRIPTION
Setting the `images` input as required is causing validation errors in my GitHub Actions extension.   Per the description, it seems like the value should actually be set to `required: false`

This Pull Request sets the required status to false instead of true.