### PR TITLE
Migrate webapps-deploy to OneDeploy

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,18 @@ inputs:
   resource-group-name:
     description: 'Enter the resource group name of the web app'
     required: false
+  type:
+    description: 'Enter deployment type (JAR, WAR, EAR, ZIP, Static)'
+    required: false
+  target-path:
+    description: "Target path in the web app. For ex. '/home/site/wwwroot'"
+    required: false
+  clean:
+    description: 'Delete existing files target directory before deploying'
+    required: false
+  restart:
+    description: 'Restart the app service after deployment'
+    required: false
     
 outputs:
   webapp-url:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webapps-deploy",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "webapps-deploy",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@actions/core": "^1.10.0",
         "@actions/github": "^4.0.0",
         "actions-secret-parser": "^1.0.4",
-        "azure-actions-appservice-rest": "^1.3.10",
+        "azure-actions-appservice-rest": "^1.3.13",
         "azure-actions-utility": "^1.0.3",
         "azure-actions-webclient": "^1.1.1"
       },
@@ -1381,9 +1381,9 @@
       "dev": true
     },
     "node_modules/azure-actions-appservice-rest": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/azure-actions-appservice-rest/-/azure-actions-appservice-rest-1.3.10.tgz",
-      "integrity": "sha512-FJtXEBr9PeMWH3x5SvTGvNED6Xe7scGkMVNrm6aK0fgwZMXSMFpzwEqIYSUzNYRLBzjh1ZKx8jJRqmVO8LRUFw==",
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/azure-actions-appservice-rest/-/azure-actions-appservice-rest-1.3.13.tgz",
+      "integrity": "sha512-Lgvxq3MAnAEKeNxelqewasYorSvWCMEBB7rtqJ8opslg4y7zXm3qMwEgZkrZKkdFwW7aZ3j5g6O1LuwHedXmUg==",
       "dependencies": {
         "@actions/core": "^1.1.10",
         "@actions/io": "^1.0.1",
@@ -8585,9 +8585,9 @@
       "dev": true
     },
     "azure-actions-appservice-rest": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/azure-actions-appservice-rest/-/azure-actions-appservice-rest-1.3.10.tgz",
-      "integrity": "sha512-FJtXEBr9PeMWH3x5SvTGvNED6Xe7scGkMVNrm6aK0fgwZMXSMFpzwEqIYSUzNYRLBzjh1ZKx8jJRqmVO8LRUFw==",
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/azure-actions-appservice-rest/-/azure-actions-appservice-rest-1.3.13.tgz",
+      "integrity": "sha512-Lgvxq3MAnAEKeNxelqewasYorSvWCMEBB7rtqJ8opslg4y7zXm3qMwEgZkrZKkdFwW7aZ3j5g6O1LuwHedXmUg==",
       "requires": {
         "@actions/core": "^1.1.10",
         "@actions/io": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@actions/core": "^1.10.0",
     "@actions/github": "^4.0.0",
     "actions-secret-parser": "^1.0.4",
-    "azure-actions-appservice-rest": "^1.3.10",
+    "azure-actions-appservice-rest": "^1.3.13",
     "azure-actions-utility": "^1.0.3",
     "azure-actions-webclient": "^1.1.1"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapps-deploy",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Deploy web apps and containerized web apps to Azure",
   "main": "lib/main.js",
   "scripts": {

--- a/src/DeploymentProvider/Providers/WebAppDeploymentProvider.ts
+++ b/src/DeploymentProvider/Providers/WebAppDeploymentProvider.ts
@@ -10,48 +10,49 @@ import { addAnnotation } from 'azure-actions-appservice-rest/Utilities/Annotatio
 export class WebAppDeploymentProvider extends BaseWebAppDeploymentProvider {
 
     public async DeployWebAppStep() {
-        var deploymentType;
         let appPackage: Package = this.actionParams.package;
         let webPackage = appPackage.getPath();
 
+        const validTypes = ["war", "jar", "ear", "zip", "static"];
+
         // kudu warm up
         await this.kuduServiceUtility.warmpUp(); 
-        
-        let packageType = appPackage.getPackageType();
 
-        switch(packageType){
-            case PackageType.war:
-                core.debug("Initiated deployment via kudu service for webapp war package : "+ webPackage);
-                deploymentType = "war";
-                break;
-
-            case PackageType.jar:
-                core.debug("Initiated deployment via kudu service for webapp jar package : "+ webPackage);
-                deploymentType = "jar";
-                break;
-
-            case PackageType.folder:
-                let tempPackagePath = utility.generateTemporaryFolderOrZipPath(`${process.env.RUNNER_TEMP}`, false);
-                webPackage = await zipUtility.archiveFolder(webPackage, "", tempPackagePath) as string;
-                core.debug("Compressed folder into zip " +  webPackage);
-                core.debug("Initiated deployment via kudu service for webapp package : "+ webPackage);
-                deploymentType = "zip";
-                break;
-                
-            case PackageType.zip:
-                core.debug("Initiated deployment via kudu service for webapp zip package : "+ webPackage);
-                deploymentType = "zip";
-                break;
-
-            default:
-                if (!this.actionParams.type) {
-                    throw new Error('Invalid App Service package or folder path provided: ' + webPackage);
-                }
-                break;
+        // If provided, type paramater takes precidence over file package type
+        if (this.actionParams.type != null && validTypes.includes(this.actionParams.type.toLowerCase())) {
+            core.debug("Initiated deployment via kudu service for webapp" + this.actionParams.type + "package : "+ webPackage);
         }
 
-        if (!this.actionParams.type){
-            this.actionParams.type = deploymentType;
+        else {
+            // Retains the old behavior of determining the package type from the file extension if valid type is not defined
+            let packageType = appPackage.getPackageType();
+            switch(packageType){
+                case PackageType.war:
+                    core.debug("Initiated deployment via kudu service for webapp war package : "+ webPackage);
+                    this.actionParams.type = "war";
+                    break;
+    
+                case PackageType.jar:
+                    core.debug("Initiated deployment via kudu service for webapp jar package : "+ webPackage);
+                    this.actionParams.type = "jar";
+                    break;
+    
+                case PackageType.folder:
+                    let tempPackagePath = utility.generateTemporaryFolderOrZipPath(`${process.env.RUNNER_TEMP}`, false);
+                    webPackage = await zipUtility.archiveFolder(webPackage, "", tempPackagePath) as string;
+                    core.debug("Compressed folder into zip " +  webPackage);
+                    core.debug("Initiated deployment via kudu service for webapp package : "+ webPackage);
+                    this.actionParams.type = "zip";
+                    break;
+                    
+                case PackageType.zip:
+                    core.debug("Initiated deployment via kudu service for webapp zip package : "+ webPackage);
+                    this.actionParams.type = "zip";
+                    break;
+    
+                default:
+                    throw new Error('Invalid App Service package: ' + webPackage + ' or type provided: ' + this.actionParams.type);
+            }
         }
 
         this.deploymentID = await this.kuduServiceUtility.deployUsingOneDeploy(webPackage, { slotName: this.actionParams.slotName, commitMessage:this.actionParams.commitMessage }, 

--- a/src/actionparameters.ts
+++ b/src/actionparameters.ts
@@ -42,7 +42,6 @@ export class ActionParameters {
     private _clean: string;
     private _restart: string;
 
-
     private constructor(endpoint: IAuthorizer) {
         this._publishProfileContent = core.getInput('publish-profile');
         this._appName = core.getInput('app-name');
@@ -156,8 +155,7 @@ export class ActionParameters {
         return this._multiContainerConfigFile;
     }
 
-    public get type()
-    {
+    public get type() {
         return this._type;
     }
 
@@ -165,15 +163,15 @@ export class ActionParameters {
         this._type = type;
     }
 
-    public get targetPath(){
+    public get targetPath() {
         return this._targetPath;
     }
 
-    public get clean(){
+    public get clean() {
         return this._clean;
     }
 
-    public get restart(){
+    public get restart() {
         return this._restart;
     }
 }

--- a/src/actionparameters.ts
+++ b/src/actionparameters.ts
@@ -36,6 +36,13 @@ export class ActionParameters {
     private _isLinux: boolean;
     private _commitMessage: string;
 
+    // Used only for OneDeploy
+    private _type: string;
+    private _targetPath: string;
+    private _clean: string;
+    private _restart: string;
+
+
     private constructor(endpoint: IAuthorizer) {
         this._publishProfileContent = core.getInput('publish-profile');
         this._appName = core.getInput('app-name');
@@ -50,6 +57,12 @@ export class ActionParameters {
          */
         this._commitMessage = github.context.eventName === 'push' ? github.context.payload.head_commit.message.slice(0, 1000) : "";
         this._endpoint = endpoint;
+
+        // Used only for OneDeploy
+        this._type = core.getInput('type');
+        this._targetPath = core.getInput('target-path');
+        this._clean = core.getInput('clean');
+        this._restart = core.getInput('restart');
     }
 
     public static getActionParams(endpoint?: IAuthorizer) {
@@ -143,4 +156,24 @@ export class ActionParameters {
         return this._multiContainerConfigFile;
     }
 
+    public get type()
+    {
+        return this._type;
+    }
+
+    public set type(type:string) {
+        this._type = type;
+    }
+
+    public get targetPath(){
+        return this._targetPath;
+    }
+
+    public get clean(){
+        return this._clean;
+    }
+
+    public get restart(){
+        return this._restart;
+    }
 }


### PR DESCRIPTION
**NOTE:** The changes in this PR are dependent on the following PR getting merged and released: https://github.com/microsoft/pipelines-appservice-lib/pull/99. It contains the changes to the Kudu service library that webapps-deploy consumes.

This change is to move the webapps-deploy Github Action to the new OneDeploy API. It is designed to be backwards compatible with webapps-deploy@v2. Regardless, this should be released as webapps-deploy@v3 to ensure that no existing users are regressed. Usage of the new action will look something like this: 

```
- name: Deploy to Azure Web App
  id: deploy-to-webapp
  uses: azure/webapps-deploy@v3
  with:
    app-name: ${{ env.AZURE_WEBAPP_NAME }}
    publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
    package: '*.war'
    type: (jar, war, zip, static)
    clean: (true, false)
    target-path: (i.e. /home/site/wwwroot/test, /home/site/wwwroot/test.war)
    restart: (true, false)
```

The onedeploy-test branch in my fork has the required node_modules and can be used to test these changes before the piplines-appservice-lib PR gets merged. The test build can be invoked with:
```
  - name: Deploy to Azure Web App
    id: deploy-to-webapp
    uses: dannysongg/webapps-deploy-ds@onedeploy-test
```