### PR TITLE
Update action.yml to node20, node16 is deprecated line 51 is updated

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,5 +48,5 @@ branding:
   icon: 'webapp.svg'
   color: 'blue'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'lib/main.js'


### PR DESCRIPTION
update line 51 to   using: 'node20' instead of   using: 'node16'.

node 16 is deprecated