### PR TITLE
Tasks for npm install and build made conditional based on node_modules

### DIFF
--- a/.github/workflows/pr_check_webapp_dotnet_windows.yml
+++ b/.github/workflows/pr_check_webapp_dotnet_windows.yml
@@ -68,8 +68,11 @@ jobs:
     - name: Installing dependencies and building latest changes
       run: |
         cd webapps-deploy
-        npm install
-        npm run build
+        if (-NOT(TEST-PATH node_modules))
+        {
+          npm install
+          npm run build
+        }
     
     - name: Azure authentication
       uses: azure/login@v1

--- a/.github/workflows/pr_check_windows_container_pubprofile.yml
+++ b/.github/workflows/pr_check_windows_container_pubprofile.yml
@@ -7,7 +7,7 @@ on:
       - releases/*
     paths-ignore:
       - '**.md'
-  pull_request_target:
+  pull_request:
     branches:
       - master
       - 'releases/*'
@@ -84,8 +84,12 @@ jobs:
     - name: Installing dependencies and building latest changes in action
       run: |
         cd webapps-deploy
-        npm install
-        npm run build
+        if (-NOT(TEST-PATH node_modules))
+        {
+          npm install
+          npm run build
+        }
+
     - name: 'Deploy to Azure WebApp'
       uses: ./webapps-deploy/
       with:


### PR DESCRIPTION
The workflows now run npm install and npm run build conditionally.

- For master branch, node_modules are not checked in. If this folder is not present, npm install and build tasks will run.

- For releases/v2, node_modules are checked in. So, the deploy would be done using the checked in files and the build step would be skipped.
- 
Cherry picked from master