### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
     - name: 'Checking out repo code'
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
 
     - name: 'Validate build'
       run: |

--- a/.github/workflows/defaultLabels.yml
+++ b/.github/workflows/defaultLabels.yml
@@ -13,7 +13,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/stale@v3
+      - uses: actions/stale@98ed4cb500039dbcccf4bd9bedada4d0187f2757 # v3.0.19
         name: Setting issue as idle
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -24,7 +24,7 @@ jobs:
           operations-per-run: 100
           exempt-issue-labels: 'backlog'
           
-      - uses: actions/stale@v3
+      - uses: actions/stale@98ed4cb500039dbcccf4bd9bedada4d0187f2757 # v3.0.19
         name: Setting PR as idle
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/github_actions_test_releases_v2.yml
+++ b/.github/workflows/github_actions_test_releases_v2.yml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
       
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Modify the sample app
         run: |
@@ -29,7 +29,7 @@ jobs:
           echo "The placeholder has been replaced with current UTC time: $current_utc_time"
 
       - name: Set up .NET Core
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '8.x'
 
@@ -40,7 +40,7 @@ jobs:
         run: dotnet publish dotnetapp/DOTNET_8_APP.csproj -c Release -o myapp
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: .net-app
           path: myapp
@@ -61,7 +61,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: modify Node.js App
         run: |
@@ -72,7 +72,7 @@ jobs:
           echo "The placeholder has been replaced with current UTC time: $current_utc_time"
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: '20.x'
 
@@ -84,7 +84,7 @@ jobs:
           npm run test --if-present
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: node-app
           path: nodeapp

--- a/.github/workflows/github_actions_test_releases_v3.yml
+++ b/.github/workflows/github_actions_test_releases_v3.yml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
       
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Modify the sample app
         run: |
@@ -29,7 +29,7 @@ jobs:
           echo "The placeholder has been replaced with current UTC time: $current_utc_time"
 
       - name: Set up .NET Core
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '8.x'
 
@@ -40,7 +40,7 @@ jobs:
         run: dotnet publish dotnetapp/DOTNET_8_APP.csproj -c Release -o myapp
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: .net-app
           path: myapp
@@ -61,7 +61,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: modify Node.js App
         run: |
@@ -72,7 +72,7 @@ jobs:
           echo "The placeholder has been replaced with current UTC time: $current_utc_time"
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: '18.x'
 
@@ -84,13 +84,13 @@ jobs:
           npm run test --if-present
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: node-app
           path: nodeapp
 
       - name: Login to Azure
-        uses: azure/login@v2
+        uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1
         with:
           client-id: ${{ secrets.AZUREAPPSERVICE_CLIENTID_NODEAPP1 }}
           tenant-id: ${{ secrets.AZUREAPPSERVICE_TENANTID }}

--- a/.github/workflows/github_actions_test_v2.yml
+++ b/.github/workflows/github_actions_test_v2.yml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
       
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Modify the sample app
         run: |
@@ -29,7 +29,7 @@ jobs:
           echo "The placeholder has been replaced with current UTC time: $current_utc_time"
 
       - name: Set up .NET Core
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '8.x'
 
@@ -40,14 +40,14 @@ jobs:
         run: dotnet publish dotnetapp/DOTNET_8_APP.csproj -c Release -o myapp
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: .net-app
           path: myapp
 
       - name: Deploy to Azure Web App
         id: deploy-to-webapp
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@5cfb776471c748b351e1ebf5770e208a54ace016 # v2.2.19
         with:
           app-name: 'lwasv2-euap-dotnet-githubactionstest-v2'
           slot-name: 'Production'
@@ -61,7 +61,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: modify Node.js App
         run: |
@@ -72,7 +72,7 @@ jobs:
           echo "The placeholder has been replaced with current UTC time: $current_utc_time"
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: '20.x'
 
@@ -84,14 +84,14 @@ jobs:
           npm run test --if-present
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: node-app
           path: nodeapp
       
       - name: 'Deploy to Azure Web App'
         id: deploy-to-webapp
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@5cfb776471c748b351e1ebf5770e208a54ace016 # v2.2.19
         with:
           app-name: 'lwasv2-euap-node-githubactions-v2'
           slot-name: 'Production'

--- a/.github/workflows/github_actions_test_v3.yml
+++ b/.github/workflows/github_actions_test_v3.yml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
       
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Modify the sample app
         run: |
@@ -29,7 +29,7 @@ jobs:
           echo "The placeholder has been replaced with current UTC time: $current_utc_time"
 
       - name: Set up .NET Core
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '8.x'
 
@@ -40,14 +40,14 @@ jobs:
         run: dotnet publish dotnetapp/DOTNET_8_APP.csproj -c Release -o myapp
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: .net-app
           path: myapp
 
       - name: Deploy to Azure Web App
         id: deploy-to-webapp
-        uses: azure/webapps-deploy@v3
+        uses: azure/webapps-deploy@02a81bead70021f5284939794bcec79c271ab383 # v3.0.8
         with:
           app-name: 'lwasv2-euap-dotnet-githubactionstest-v3'
           slot-name: 'Production'
@@ -61,7 +61,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: modify Node.js App
         run: |
@@ -72,7 +72,7 @@ jobs:
           echo "The placeholder has been replaced with current UTC time: $current_utc_time"
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: '18.x'
 
@@ -84,14 +84,14 @@ jobs:
           npm run test --if-present
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: node-app
           path: nodeapp
       
       - name: 'Deploy to Azure Web App'
         id: deploy-to-webapp
-        uses: azure/webapps-deploy@v3
+        uses: azure/webapps-deploy@02a81bead70021f5284939794bcec79c271ab383 # v3.0.8
         with:
           app-name: 'lwasv2-euap-node-githubactions-v3'
           slot-name: 'Production'

--- a/.github/workflows/pr_check_webapp_dotnet_windows.yml
+++ b/.github/workflows/pr_check_webapp_dotnet_windows.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     
     - uses: actions/checkout@master
       with:
@@ -46,7 +46,7 @@ jobs:
         path: 'dotnetsample'
 
     - name: Install Nuget
-      uses: nuget/setup-nuget@v1
+      uses: nuget/setup-nuget@296fd3ccf8528660c91106efefe2364482f86d6f # v1.2.0
       with:
         nuget-version: ${{ env.NUGET_VERSION}}
     - name: NuGet to restore dependencies as well as project-specific tools that are specified in the project file
@@ -56,12 +56,12 @@ jobs:
           nuget restore
       
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@c26a08ba26249b81327e26f6ef381897b6a8754d # v1.0.2
     
     - name: Run MSBuild
       run: msbuild .\dotnetsample\SampleWebApplication.sln
     
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
       name: Checkout from PR branch
       with: 
         repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -75,7 +75,7 @@ jobs:
         npm run package
     
     - name: Azure authentication
-      uses: azure/login@v2
+      uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1
       with:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/pr_check_windows_container_pubprofile.yml
+++ b/.github/workflows/pr_check_windows_container_pubprofile.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout from PR branch
-      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         path: 'webapps-deploy'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           echo "branch=releases/${MAJOR}" >> $GITHUB_OUTPUT
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ inputs.revert == true && inputs.tag || steps.version.outputs.branch }}
           fetch-depth: 0

--- a/.github/workflows/windows_container_pubprofile_deploy.yml
+++ b/.github/workflows/windows_container_pubprofile_deploy.yml
@@ -26,7 +26,7 @@ jobs:
       id-token: write
     steps:
     - name: 'Checkout Github Action'
-      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         repository: GH-ACE/python_container_App
         ref: main
@@ -44,7 +44,7 @@ jobs:
       run: docker logout ${{ env.CONTAINER_REGISTRY }}
 
     - name: Login to Azure Container Registry
-      uses: azure/docker-login@83efeb77770c98b620c73055fbb59b2847e17dc0 # v1
+      uses: azure/docker-login@83efeb77770c98b620c73055fbb59b2847e17dc0 # v1.0.1
       with:
         login-server: ${{ env.CONTAINER_REGISTRY }}
         username: ${{ secrets.WEBDEPLOY_TEST_ACR_USERNAME }}
@@ -58,7 +58,7 @@ jobs:
         docker push ${{ env.CONTAINER_REGISTRY }}/containerwebapp/canaryreplica:latest
 
     - name: Set Web App ACR authentication
-      uses: Azure/appservice-settings@1808c4fbba4b8723107948a295d396a5c0e33dcd # v1
+      uses: Azure/appservice-settings@1808c4fbba4b8723107948a295d396a5c0e33dcd # v1.1.1
       with:
         app-name: ${{ env.AZURE_WEBAPP_NAME }}
         app-settings-json: |
@@ -81,7 +81,7 @@ jobs:
           ]
 
     - name: Checkout trusted action commit
-      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         path: 'webapps-deploy'
         persist-credentials: false


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes in action execution are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
